### PR TITLE
修复Linux Mint 20 Cinnamon重启后无法进入桌面的问题

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,8 @@ Pin-Priority: 200
 EOF
 
 # 添加XDG_DATA_DIRS配置，使得应用图标能正常显示
-sudo tee "/etc/profile.d/deepin-wine.i-m.dev.sh" >/dev/null << "EOF"
+# Linux Mint 20 cinnamon，文件名前面加个z前缀，最后加载
+sudo tee "/etc/profile.d/z-deepin-wine.i-m.dev.sh" >/dev/null << "EOF"
 for deepin_dir in /opt/apps/*/entries; do
     export XDG_DATA_DIRS="$XDG_DATA_DIRS:$deepin_dir"
 done
@@ -37,7 +38,7 @@ sudo apt-get update --no-list-cleanup -o Dir::Etc::sourcelist="$LIST_FILE" -o Di
 printf "
 \033[32m大功告成，现在可以试试安装deepin-wine软件了，如：
 安装/更新微信：sudo apt-get install com.qq.weixin.deepin
-安装/更新QQ：sudo apt-get com.qq.im.deepin
+安装/更新QQ：sudo apt-get install com.qq.im.deepin
 安装/更新钉钉：sudo apt-get install com.dingtalk.deepin
 \033[33;1m由于新版变化，安装完成后需要注销重登录才能正常显示应用图标。
 \033[36m如果觉得有用，请到 https://github.com/zq1997/deepin-wine 点个star吧。


### PR DESCRIPTION
适配deepin V20 之后的脚本对图标库的处理和以前不同，通过这个线索，发现flatpak.sh文件也定义了XDG_DATA_DIRS变量。
猜测是因为deepin-wine.i-m.dev.sh比它加载早，所以导致无法进入桌面，所以给这个文件加了个前缀z。
这个改动对其他发行版应该也没有影响。